### PR TITLE
Update main.c

### DIFF
--- a/main.c
+++ b/main.c
@@ -677,7 +677,7 @@ static int mtp02_probe(struct spi_device *spi)
 	return retval;
 }
 
-static int mtp02_remove(struct spi_device *spi)
+static void mtp02_remove(struct spi_device *spi)
 {
 	struct mtp02_device	*device = spi_get_drvdata(spi);
 


### PR DESCRIPTION
manjaro-test successful

correction:
spi_driver
.remove is now void-return type.

log:
[dennis@devt devterm-printer]$ make
make -C /lib/modules/5.18.1-1-MANJARO-ARM-DEVTERM/build M=/home/dennis/devterm-printer modules
make[1]: Verzeichnis „/usr/lib/modules/5.18.1-1-MANJARO-ARM-DEVTERM/build“ wird betreten
  CC [M]  /home/dennis/devterm-printer/main.o
/home/dennis/devterm-printer/main.c:724:33: Fehler: Initialisierung von »void (*)(struct spi_device *)« von inkompatiblem Zeigertyp »int (*)(struct spi_device *)« [-Werror=incompatible-pointer-types]
  724 |                 .remove =       mtp02_remove,
      |                                 ^~~~~~~~~~~~
/home/dennis/devterm-printer/main.c:724:33: Anmerkung: (nahe der Initialisierung für »mtp02_spi_driver.remove«)
cc1: Einige Warnungen werden als Fehler behandelt
make[2]: *** [scripts/Makefile.build:288: /home/dennis/devterm-printer/main.o] Fehler 1
make[1]: *** [Makefile:1834: /home/dennis/devterm-printer] Fehler 2
make[1]: Verzeichnis „/usr/lib/modules/5.18.1-1-MANJARO-ARM-DEVTERM/build“ wird verlassen
make: *** [Makefile:22: all] Fehler 2

[dennis@devt devterm-printer]$ gcc -v
Es werden eingebaute Spezifikationen verwendet.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/aarch64-unknown-linux-gnu/12.1.0/lto-wrapper
Ziel: aarch64-unknown-linux-gnu
Konfiguriert mit: /build/gcc/src/gcc/configure --enable-languages=c,c++,fortran,go,lto,objc,obj-c++ --enable-bootstrap --prefix=/usr --libdir=/usr/lib --libexecdir=/usr/lib --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=https://github.com/archlinuxarm/PKGBUILDs/issues --with-linker-hash-style=gnu --with-system-zlib --enable-__cxa_atexit --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-default-ssp --enable-gnu-indirect-function --enable-gnu-unique-object --enable-linker-build-id --enable-lto --enable-plugin --enable-shared --enable-threads=posix --disable-libssp --disable-libstdcxx-pch --disable-multilib --disable-werror --host=aarch64-unknown-linux-gnu --build=aarch64-unknown-linux-gnu --with-arch=armv8-a --enable-fix-cortex-a53-835769 --enable-fix-cortex-a53-843419
Thread-Modell: posix
Unterstützte LTO-Kompressionsalgorithmen: zlib zstd
gcc-Version 12.1.0 (GCC)